### PR TITLE
Narrow click and drag of the graph to clicks on the data itself, not on the axes or margins.

### DIFF
--- a/LIBS/DataDashes.Lib.dog
+++ b/LIBS/DataDashes.Lib.dog
@@ -276,8 +276,13 @@ struct graph: inherits=dash{
     me int: prevX
     me int: deltaX <- 0
     me int: moveThreshold <- 2
+    me int: crntX
+    me int: crntY
 
     me bool: primaryDn(their GUI_ButtonEvent: event) <- {
+	crntX <- event.x - posX
+	crntY <- event.y - posY
+	if (crntX <= 0 or crntX >= width or crntY <= 0 or crntY >= height) {return(false)}
 	if (scrollState==still) {
 	    scrollState <- fingerPressed
 	    prevX <- event.x


### PR DESCRIPTION
When initially creating the scroll functionally I left off this condition to simplify things.