### PR TITLE
Add method to create circle in GTK3. Add missing methods to GUI_ctxt

### DIFF
--- a/LIBS/GUI_ToolKit.GTK3.Lib.dog
+++ b/LIBS/GUI_ToolKit.GTK3.Lib.dog
@@ -537,6 +537,7 @@ struct GUI_ctxt {
     me void: strokeKeep() <- <%!cairo_stroke_preserve(%0)%>
     me void: fillKeep() <- <%!cairo_fill_preserve(%0)%>
     me void: setFillPattern() <- <%!cairo_set_source(%0, %1)%>
+    me void: circle(me int: centerX, me int: centerY, me int: radius) <- <%!cairo_arc(%0, %1, %2, %3, 0, 2 * M_PI)%>
 }
 
 struct guiFillPattern{

--- a/LIBS/GUI_ToolKit.Lib.dog
+++ b/LIBS/GUI_ToolKit.Lib.dog
@@ -100,16 +100,23 @@ struct GUI_ctxt {
     me void: setRGB (me double: red, me double: green, me double: blue)
     me void: setColor(me cdColor: color)
     me void: setLineWidth(me double: width)
+    me void: finishPDF()
+    me void: setScale()
     me void: moveTo(me double: x, me double: y)
     me void: lineTo(me double: x, me double: y)
     me void: moveRel(me double: dx, me double: dy)
     me void: lineRel(me double: dx, me double: dy)
     me void: curveTo(me double: x1, me double: y1, me double: x2, me double: y2, me double: x3, me double: y3)
     me void: curveRel(me double: dx1, me double: dy1, me double: dx2, me double: dy2, me double: dx3, me double: dy3)
+    me void: closePath()
     me void: rectangle()
     me void: paintNow()
     me void: strokeNow()
     me void: fillNow()
+    me void: strokeKeep()
+    me void: fillKeep()
+    me void: setFillPattern()
+    me void: circle(me int: centerX, me int: centerY, me int: radius)
 }
 
 


### PR DESCRIPTION
Partial housekeeping of GUI_ctxt: copied methods present in GTK3.Lib but not in base Lib over to base Lib. Did not yet address missing parameters or search other platform Libs for other missing methods.