### PR TITLE
Automate setting up libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,4 @@ testLibResults/
 *.info
 LibraryAnalysisReport.txt
 
-
-
+.idea

--- a/Examples/AutoDownload.dog
+++ b/Examples/AutoDownload.dog
@@ -1,0 +1,28 @@
+// AutoDownload.dog
+
+LinuxBuild: Platform='Linux' CPU='amd64' Lang='CPP' optimize='speed';
+//SwingBuild: Platform='Java' CPU='JavaVM' Lang='Java' optimize='speed';
+//AndroidBuild: Platform='Android' CPU='JavaVM' Lang='Java' optimize='power';
+//iPhoneBuild: Platform='IOS' CPU='amd64' Lang='Swift' optimize='speed';
+//MacBuild: Platform='MacOS' Lang='Swift' optimize='speed';
+
+Title = "Auto Download"
+FileName = "autodownload"
+Version = "1.0"
+CopyrightMesg = "Public Domain"
+Authors = "Bruce Long"
+Description = "This is an example of a very minimal program"
+ProgramOrLibrary = "program"
+
+featuresNeeded = [Quic]
+
+LicenseText = `Public Domain`
+
+
+runCode=`runProg()`
+
+struct GLOBAL{
+    void: runProg()<-{
+        print("Hello World!\n")
+    }
+}

--- a/LIBS/Quic.CPP.Lib.dog
+++ b/LIBS/Quic.CPP.Lib.dog
@@ -7,7 +7,7 @@ interface={
     provides=[Quic_implementation]
     packages = [
         { packageName = 'lsQuic'
-          fetchMethod = 'git:https://github.com/litespeedtech/lsquic.git:commit=7fc1254' // could start with git, zip, file, system, etc. (system = apt install lib...)
+          fetchMethod = 'git:https://github.com/litespeedtech/lsquic.git' // could start with git, zip, file, system, etc. (system = apt install lib...)
           updateWhen  = 'never'    // Updating isn't implemented
           buildCmds   = [
               [linux,   'cmake . && make', ['src/lsquic.a',   'includes/lsquic.h']], // How to build and files to install for Linux
@@ -15,6 +15,33 @@ interface={
           ]
         },
 
+        { packageName = 'HTMLfile'
+          fetchMethod = 'file:https://file-examples-com.github.io/uploads/2017/02/index.html'
+          updateWhen  = 'never'    // Updating isn't implemented
+          buildCmds   = [
+              [linux,   'cmake . && make', ['src/lsquic.a',   'includes/lsquic.h']],
+              [windows, 'cmake . && make', ['src/lsquic.dll', 'includes/lsquic.h']]
+          ]
+        },
+
+        { packageName = 'zipcode'
+          fetchMethod = 'zip:https://file-examples-com.github.io/uploads/2017/02/zip_5MB.zip'
+          updateWhen  = 'never'    // Updating isn't implemented
+          buildCmds   = [
+              [linux,   'cmake . && make', ['src/lsquic.a',   'includes/lsquic.h']], // How to build and files to install for Linux
+              [windows, 'cmake . && make', ['src/lsquic.dll', 'includes/lsquic.h']]
+          ]
+        },
+
+        { packageName = 'code'
+          fetchMethod = 'zip:http://www.sbeams.org/sample_data/Proteomics/yeast_orfs.new.20040422.gz'
+          updateWhen  = 'never'    // Updating isn't implemented
+          buildCmds   = [
+              [linux,   'cmake . && make', ['src/lsquic.a',   'includes/lsquic.h']], // How to build and files to install for Linux
+              [windows, 'cmake . && make', ['src/lsquic.dll', 'includes/lsquic.h']]
+          ]
+        }
+/*
         { packageName = 'crypto'
           fetchMethod = 'git:https://github.com/litespeedtech/lsquic.git:commit=7fc1254'
           updateWhen  = 'never'     // Updating isn't implemented
@@ -28,7 +55,7 @@ interface={
           fetchmethod = 'system: install z, z-dev'
         },
 
-        { packageName = 'system'}
+        { packageName = 'system'}*/
     ]
     libFiles=[lsquic, ssl, crypto, z, m]
     headers=[netinet/in.h, netinet/ip.h, arpa/inet.h, sys/types.h, sys/socket.h, netdb.h, openssl/pem.h, openssl/x509.h, openssl/ssl.h, ev.c, lsquic.h]

--- a/codeDog
+++ b/codeDog
@@ -100,10 +100,12 @@ def GenerateSystem(classes, buildSpecs, tags, macroDefs):
             if 'interface' in tagsFromLibFiles[lib] and 'libFiles' in tagsFromLibFiles[lib]['interface']:
                 tmpLibFiles = tagsFromLibFiles[lib]['interface']['libFiles']
                 libFiles+=tmpLibFiles
+                if 'packages' in tagsFromLibFiles[lib]['interface']:
+                    packageData = tagsFromLibFiles[lib]['interface']['packages']
         #TODO: need debug mode and minimum version
         platform=progSpec.fetchTagValue([tags, buildTags], 'Platform')
         #cdlog(1, "\nWRITING {} FILE(S) AND COMPILING...".format(len(fileSpecs)))
-        buildDog.build("-g", '14',  fileName, labelName, launchIconName, libFiles, buildName, platform, fileSpecs, programOrLibrary)
+        buildDog.build("-g", '14',  fileName, labelName, launchIconName, libFiles, buildName, platform, fileSpecs, programOrLibrary, packageData)
         print("Marker: Build Successful")
         progSpec.rollBack(classes, tags)
     # GenerateDocuments()


### PR DESCRIPTION
In addition to 'git', the download type can be: file: just download the file; zip: download and unzip it. (also support .gz, etc); and system: on Linux, use apt-install. // For this one just leave a slot in the code. We will implement it later. (CONTINUE WORKING)